### PR TITLE
chore: rename package to @ngrx-toolkit/core

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # NgRx Toolkit
 
-[![npm](https://img.shields.io/npm/v/%40angular-architects%2Fngrx-toolkit.svg)](https://www.npmjs.com/package/%40angular-architects%2Fngrx-toolkit)
+[![npm](https://img.shields.io/npm/v/%40ngrx-toolkit%2Fcore.svg)](https://www.npmjs.com/package/%40ngrx-toolkit%2Fcore)
 
-<a href="https://angular-architects.github.io/ngrx-toolkit/"><img src="https://raw.githubusercontent.com/angular-architects/ngrx-toolkit/main/logo.png" width="320" style="text-align: center" /></a>
+<a href="https://ngrx-toolkit.github.io/ngrx-toolkit/"><img src="https://raw.githubusercontent.com/ngrx-toolkit/ngrx-toolkit/main/logo.png" width="320" style="text-align: center" /></a>
 
 NgRx Toolkit is a set of extensions to the NgRx Signals Store, like
 
@@ -11,10 +11,12 @@ NgRx Toolkit is a set of extensions to the NgRx Signals Store, like
 - Storage Sync: Synchronize the Store with Web Storage
 - [Redux Connector: Map NgRx Store Actions to a present Signal Store](libs/ngrx-toolkit/redux-connector/docs/README.md)
 
+> Starting with v22, the package is published as `@ngrx-toolkit/core`. For v21 and earlier, use `@angular-architects/ngrx-toolkit`.
+
 To install it, run
 
 ```shell
-npm i @angular-architects/ngrx-toolkit
+npm i @ngrx-toolkit/core
 ```
 
 For a more detailed guide on installation, setup, and usage, head to the [**Documentation**](https://ngrx-toolkit.angulararchitects.io/).

--- a/apps/demo/src/app/category.store.ts
+++ b/apps/demo/src/app/category.store.ts
@@ -1,4 +1,4 @@
-import { withDevtools } from '@angular-architects/ngrx-toolkit';
+import { withDevtools } from '@ngrx-toolkit/core';
 import { patchState, signalStore, withHooks } from '@ngrx/signals';
 import { setAllEntities, withEntities } from '@ngrx/signals/entities';
 

--- a/apps/demo/src/app/counter-mutation/counter.store.ts
+++ b/apps/demo/src/app/counter-mutation/counter.store.ts
@@ -3,7 +3,7 @@ import {
   httpMutation,
   rxMutation,
   withMutations,
-} from '@angular-architects/ngrx-toolkit';
+} from '@ngrx-toolkit/core';
 import { patchState, signalStore, withState } from '@ngrx/signals';
 import { delay, Observable } from 'rxjs';
 

--- a/apps/demo/src/app/counter-rx-mutation/counter-rx-mutation.ts
+++ b/apps/demo/src/app/counter-rx-mutation/counter-rx-mutation.ts
@@ -1,10 +1,6 @@
-import {
-  concatOp,
-  httpMutation,
-  rxMutation,
-} from '@angular-architects/ngrx-toolkit';
 import { CommonModule } from '@angular/common';
 import { Component, computed, signal } from '@angular/core';
+import { concatOp, httpMutation, rxMutation } from '@ngrx-toolkit/core';
 import { delay, Observable, of, throwError } from 'rxjs';
 
 export type Params = {

--- a/apps/demo/src/app/devtools/todo-detail.component.ts
+++ b/apps/demo/src/app/devtools/todo-detail.component.ts
@@ -1,11 +1,11 @@
+import { Component, effect, inject, input } from '@angular/core';
+import { MatCardModule } from '@angular/material/card';
 import {
   renameDevtoolsName,
   withDevtools,
   withGlitchTracking,
   withMapper,
-} from '@angular-architects/ngrx-toolkit';
-import { Component, effect, inject, input } from '@angular/core';
-import { MatCardModule } from '@angular/material/card';
+} from '@ngrx-toolkit/core';
 import { patchState, signalStore, withHooks, withState } from '@ngrx/signals';
 import { Todo } from '../shared/todo.service';
 

--- a/apps/demo/src/app/devtools/todo-store.ts
+++ b/apps/demo/src/app/devtools/todo-store.ts
@@ -1,5 +1,5 @@
-import { updateState, withDevtools } from '@angular-architects/ngrx-toolkit';
 import { computed, inject } from '@angular/core';
+import { updateState, withDevtools } from '@ngrx-toolkit/core';
 import {
   signalStore,
   withComputed,

--- a/apps/demo/src/app/events-sample/book.store.ts
+++ b/apps/demo/src/app/events-sample/book.store.ts
@@ -2,7 +2,7 @@ import {
   withDevtools,
   withGlitchTracking,
   withTrackedReducer,
-} from '@angular-architects/ngrx-toolkit';
+} from '@ngrx-toolkit/core';
 import { signalStore, withComputed, withHooks, withState } from '@ngrx/signals';
 import { injectDispatch, on } from '@ngrx/signals/events';
 import { bookEvents } from './book-events';

--- a/apps/demo/src/app/feature-factory/feature-factory.component.ts
+++ b/apps/demo/src/app/feature-factory/feature-factory.component.ts
@@ -1,7 +1,7 @@
-import { withFeatureFactory } from '@angular-architects/ngrx-toolkit';
 import { Component, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatButton } from '@angular/material/button';
+import { withFeatureFactory } from '@ngrx-toolkit/core';
 import {
   patchState,
   signalStore,

--- a/apps/demo/src/app/flight-search-data-service-dynamic/flight-booking.store.ts
+++ b/apps/demo/src/app/flight-search-data-service-dynamic/flight-booking.store.ts
@@ -6,7 +6,7 @@ import {
   withCallState,
   withDataService,
   withUndoRedo,
-} from '@angular-architects/ngrx-toolkit';
+} from '@ngrx-toolkit/core';
 import { withEntities } from '@ngrx/signals/entities';
 import { Flight } from '../shared/flight';
 

--- a/apps/demo/src/app/flight-search-data-service-simple/flight-booking-simple.store.ts
+++ b/apps/demo/src/app/flight-search-data-service-simple/flight-booking-simple.store.ts
@@ -6,7 +6,7 @@ import {
   withCallState,
   withDataService,
   withUndoRedo,
-} from '@angular-architects/ngrx-toolkit';
+} from '@ngrx-toolkit/core';
 import { withEntities } from '@ngrx/signals/entities';
 import { Flight } from '../shared/flight';
 

--- a/apps/demo/src/app/flight-search-redux-connector/+state/redux.ts
+++ b/apps/demo/src/app/flight-search-redux-connector/+state/redux.ts
@@ -2,7 +2,7 @@ import {
   createReduxState,
   mapAction,
   withActionMappers,
-} from '@angular-architects/ngrx-toolkit/redux-connector';
+} from '@ngrx-toolkit/core/redux-connector';
 import { ticketActions } from './actions';
 import { FlightStore } from './store';
 

--- a/apps/demo/src/app/flight-search-redux-connector/+state/store.ts
+++ b/apps/demo/src/app/flight-search-redux-connector/+state/store.ts
@@ -1,5 +1,5 @@
-import { reduxMethod } from '@angular-architects/ngrx-toolkit/redux-connector';
 import { computed, inject } from '@angular/core';
+import { reduxMethod } from '@ngrx-toolkit/core/redux-connector';
 import {
   patchState,
   signalStore,

--- a/apps/demo/src/app/flight-search-with-pagination/flight-store.ts
+++ b/apps/demo/src/app/flight-search-with-pagination/flight-store.ts
@@ -4,7 +4,7 @@ import {
   withCallState,
   withDataService,
   withPagination,
-} from '@angular-architects/ngrx-toolkit';
+} from '@ngrx-toolkit/core';
 import { patchState, signalStore, type, withMethods } from '@ngrx/signals';
 import { withEntities } from '@ngrx/signals/entities';
 import { Flight } from '../shared/flight';

--- a/apps/demo/src/app/flight-search/flight-store.ts
+++ b/apps/demo/src/app/flight-search/flight-store.ts
@@ -1,12 +1,12 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { inject } from '@angular/core';
 import {
   noPayload,
   payload,
   updateState,
   withDevtools,
   withRedux,
-} from '@angular-architects/ngrx-toolkit';
-import { HttpClient, HttpParams } from '@angular/common/http';
-import { inject } from '@angular/core';
+} from '@ngrx-toolkit/core';
 import { signalStore, withState } from '@ngrx/signals';
 import { map, switchMap } from 'rxjs';
 import { Flight } from './flight';

--- a/apps/demo/src/app/immutable-state/immutable-state.component.ts
+++ b/apps/demo/src/app/immutable-state/immutable-state.component.ts
@@ -1,7 +1,7 @@
-import { withImmutableState } from '@angular-architects/ngrx-toolkit';
 import { Component, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatButton } from '@angular/material/button';
+import { withImmutableState } from '@ngrx-toolkit/core';
 import { patchState, signalStore, withMethods } from '@ngrx/signals';
 
 const initialState = { user: { id: 1, name: 'Konrad' } };

--- a/apps/demo/src/app/reset/todo-store.ts
+++ b/apps/demo/src/app/reset/todo-store.ts
@@ -1,4 +1,4 @@
-import { setResetState, withReset } from '@angular-architects/ngrx-toolkit';
+import { setResetState, withReset } from '@ngrx-toolkit/core';
 import {
   getState,
   patchState,

--- a/apps/demo/src/app/shared/flight.service.ts
+++ b/apps/demo/src/app/shared/flight.service.ts
@@ -1,6 +1,6 @@
-import { DataService } from '@angular-architects/ngrx-toolkit';
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
+import { DataService } from '@ngrx-toolkit/core';
 import { EntityId } from '@ngrx/signals/entities';
 import { firstValueFrom, Observable } from 'rxjs';
 import { Flight } from './flight';

--- a/apps/demo/src/app/todo-entity-resource/todo-entity-resource.store.ts
+++ b/apps/demo/src/app/todo-entity-resource/todo-entity-resource.store.ts
@@ -1,9 +1,9 @@
+import { inject, resource } from '@angular/core';
 import {
   httpMutation,
   withEntityResources,
   withMutations,
-} from '@angular-architects/ngrx-toolkit';
-import { inject, resource } from '@angular/core';
+} from '@ngrx-toolkit/core';
 import { patchState, signalStore, withMethods, withState } from '@ngrx/signals';
 import { addEntity, removeEntity, updateEntity } from '@ngrx/signals/entities';
 import { firstValueFrom } from 'rxjs';

--- a/apps/demo/src/app/todo-indexeddb-sync/synced-todo-store.ts
+++ b/apps/demo/src/app/todo-indexeddb-sync/synced-todo-store.ts
@@ -1,8 +1,5 @@
-import {
-  withIndexedDB,
-  withStorageSync,
-} from '@angular-architects/ngrx-toolkit';
 import { inject } from '@angular/core';
+import { withIndexedDB, withStorageSync } from '@ngrx-toolkit/core';
 import { getState, patchState, signalStore, withMethods } from '@ngrx/signals';
 import {
   removeEntity,

--- a/apps/demo/src/app/todo-storage-sync/synced-todo-store.ts
+++ b/apps/demo/src/app/todo-storage-sync/synced-todo-store.ts
@@ -1,8 +1,5 @@
-import {
-  withLocalStorage,
-  withStorageSync,
-} from '@angular-architects/ngrx-toolkit';
 import { inject } from '@angular/core';
+import { withLocalStorage, withStorageSync } from '@ngrx-toolkit/core';
 import { getState, patchState, signalStore, withMethods } from '@ngrx/signals';
 import {
   removeEntity,

--- a/apps/demo/src/app/with-conditional/conditional.component.ts
+++ b/apps/demo/src/app/with-conditional/conditional.component.ts
@@ -1,4 +1,3 @@
-import { withConditional } from '@angular-architects/ngrx-toolkit';
 import { Component, effect, inject, signal, untracked } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatButton } from '@angular/material/button';
@@ -6,6 +5,7 @@ import {
   MatButtonToggle,
   MatButtonToggleGroup,
 } from '@angular/material/button-toggle';
+import { withConditional } from '@ngrx-toolkit/core';
 import {
   patchState,
   signalStore,

--- a/apps/demo/src/app/with-resource/with-resource.component.ts
+++ b/apps/demo/src/app/with-resource/with-resource.component.ts
@@ -1,7 +1,7 @@
-import { withResource } from '@angular-architects/ngrx-toolkit';
 import { JsonPipe } from '@angular/common';
 import { httpResource } from '@angular/common/http';
 import { Component, inject } from '@angular/core';
+import { withResource } from '@ngrx-toolkit/core';
 import { signalStore, withState } from '@ngrx/signals';
 import { Flight } from '../shared/flight';
 

--- a/docs/docs/create-redux-state.md
+++ b/docs/docs/create-redux-state.md
@@ -3,12 +3,12 @@ title: createReduxState()
 ---
 
 ```typescript
-import { createReduxState } from '@angular-architects/ngrx-toolkit/redux-connector';
+import { createReduxState } from '@ngrx-toolkit/core/redux-connector';
 ```
 
 The Redux Connector it is not an extension but turns any `signalStore()` into a Global State Management Slice following the Redux pattern.
 
-It is available as secondary entry point, i.e. `import { createReduxState } from '@angular-architects/ngrx-toolkit/redux-connector'` and has a dependency to `@ngrx/store`.
+It is available as secondary entry point, i.e. `import { createReduxState } from '@ngrx-toolkit/core/redux-connector'` and has a dependency to `@ngrx/store`.
 
 An extension without dependency to `@ngrx/store` is available with [`withRedux()`](./with-redux).
 

--- a/docs/docs/extensions.md
+++ b/docs/docs/extensions.md
@@ -4,6 +4,12 @@ title: Extensions
 
 The NgRx Toolkit is a set of extensions to the NgRx SignalsStore.
 
+:::note Package name for v22
+
+Starting with v22, install and import the toolkit as `@ngrx-toolkit/core`. For v21 and earlier, use `@angular-architects/ngrx-toolkit`.
+
+:::
+
 It offers extensions like:
 
 - [⭐️ Devtools](./with-devtools): Integration into Redux Devtools
@@ -22,5 +28,5 @@ It offers extensions like:
 To install it, run
 
 ```shell
-npm i @angular-architects/ngrx-toolkit
+npm i @ngrx-toolkit/core
 ```

--- a/docs/docs/mutations.md
+++ b/docs/docs/mutations.md
@@ -3,20 +3,20 @@ title: Mutations
 ---
 
 ```typescript
-import { httpMutation } from '@angular-architects/ngrx-toolkit';
+import { httpMutation } from '@ngrx-toolkit/core';
 ```
 
 ```typescript
-import { rxMutation } from '@angular-architects/ngrx-toolkit';
+import { rxMutation } from '@ngrx-toolkit/core';
 ```
 
 ```typescript
-import { withMutations } from '@angular-architects/ngrx-toolkit';
+import { withMutations } from '@ngrx-toolkit/core';
 ```
 
 ```typescript
 // Optional, `concatOp` is the default.
-import { concatOp, exhaustOp, mergeOp, switchOp } from '@angular-architects/ngrx-toolkit';
+import { concatOp, exhaustOp, mergeOp, switchOp } from '@ngrx-toolkit/core';
 ```
 
 ## Basic Usage
@@ -34,7 +34,7 @@ This guide covers
   - State signals available (`value/status/error/isPending`)
       <!-- TODO - resolve when #235 closed-->
     - For `httpMutation`, the response type is specified with the param `parse: (res: T) => res as T`
-    - `hasValue` signal to narrow type. ⚠️NOTE⚠️: currently there is an [outstanding bug](https://github.com/angular-architects/ngrx-toolkit/issues/235) that this does not properly narrow.
+    - `hasValue` signal to narrow type. ⚠️NOTE⚠️: currently there is an [outstanding bug](https://github.com/ngrx-toolkit/ngrx-toolkit/issues/235) that this does not properly narrow.
   - [How to use](#usage-withmutations-or-solo-functions), as:
     - _standalone functions_
     - In `withMutations` store _feature_
@@ -185,7 +185,7 @@ Enables handling race conditions
 increment: rxMutation({
   // ...
   // Passing in a custom option. Need to import like:
-  // import { switchOp } from '@angular-architects/ngrx-toolkit'
+  // import { switchOp } from '@ngrx-toolkit/core'
   operator: mergeOp, // `concatOp` is the default if `operator` is omitted
 }),
 
@@ -337,7 +337,7 @@ class CounterMutation {
   increment: rxMutation({
     // ...
     // Passing in a custom option. Need to import like:
-    // import { switchOp } from '@angular-architects/ngrx-toolkit'
+    // import { switchOp } from '@ngrx-toolkit/core'
     operator: mergeOp, // `concatOp` is the default if `operator` is omitted
   }),
 })),
@@ -410,7 +410,7 @@ This example is a dedicated store with `withMutations` and used in a component, 
 ### Declare
 
 ```ts
-import { concatOp, httpMutation, rxMutation, withMutations } from '@angular-architects/ngrx-toolkit';
+import { concatOp, httpMutation, rxMutation, withMutations } from '@ngrx-toolkit/core';
 import { patchState, signalStore, withState } from '@ngrx/signals';
 import { delay, Observable } from 'rxjs';
 

--- a/docs/docs/team.md
+++ b/docs/docs/team.md
@@ -15,4 +15,4 @@ import Team from '@site/src/components/Team';
 
 ## Contribute
 
-We welcome contributions from the community! If you're interested in contributing to NgRx Toolkit, check out our [GitHub repository](https://github.com/angular-architects/ngrx-toolkit) and our [contribution guidelines](https://github.com/angular-architects/ngrx-toolkit/blob/main/CONTRIBUTING.md).
+We welcome contributions from the community! If you're interested in contributing to NgRx Toolkit, check out our [GitHub repository](https://github.com/ngrx-toolkit/ngrx-toolkit) and our [contribution guidelines](https://github.com/ngrx-toolkit/ngrx-toolkit/blob/main/CONTRIBUTING.md).

--- a/docs/docs/with-call-state.md
+++ b/docs/docs/with-call-state.md
@@ -3,7 +3,7 @@ title: withCallState()
 ---
 
 ```typescript
-import { withCallState } from '@angular-architects/ngrx-toolkit';
+import { withCallState } from '@ngrx-toolkit/core';
 ```
 
 `withCallState` adds call state management capabilities to NgRx signal stores, tracking the status of asynchronous operations with built-in states for loading, loaded, and error conditions.
@@ -43,7 +43,7 @@ The call state can be one of these types:
 ## Usage
 
 ```typescript
-import { withCallState, setLoading, setLoaded, setError } from '@angular-architects/ngrx-toolkit';
+import { withCallState, setLoading, setLoaded, setError } from '@ngrx-toolkit/core';
 
 const store = signalStore(
   withCallState(),

--- a/docs/docs/with-conditional.md
+++ b/docs/docs/with-conditional.md
@@ -3,7 +3,7 @@ title: withConditional()
 ---
 
 ```typescript
-import { withConditional } from '@angular-architects/ngrx-toolkit';
+import { withConditional } from '@ngrx-toolkit/core';
 ```
 
 `withConditional` activates a feature based on a given condition.
@@ -21,7 +21,7 @@ Otherwise, a type error will occur.
 ## Usage
 
 ```typescript
-import { withConditional } from '@angular-architects/ngrx-toolkit';
+import { withConditional } from '@ngrx-toolkit/core';
 
 const withUser = signalStoreFeature(
   withState({ id: 1, name: 'Konrad' }),

--- a/docs/docs/with-data-service.md
+++ b/docs/docs/with-data-service.md
@@ -3,7 +3,7 @@ title: withDataService()
 ---
 
 ```typescript
-import { withDataService } from '@angular-architects/ngrx-toolkit';
+import { withDataService } from '@ngrx-toolkit/core';
 ```
 
 `withDataService()` allows to connect a Data Service to the store:
@@ -11,7 +11,7 @@ import { withDataService } from '@angular-architects/ngrx-toolkit';
 This gives you a store for a CRUD use case:
 
 ```typescript
-import { withDataService, withCallState, withUndoRedo } from '@angular-architects/ngrx-toolkit';
+import { withDataService, withCallState, withUndoRedo } from '@ngrx-toolkit/core';
 
 export const SimpleFlightBookingStore = signalStore(
   { providedIn: 'root' },
@@ -92,7 +92,7 @@ export class FlightSearchSimpleComponent {
 To avoid naming conflicts, the properties set up by `withDataService` and the connected features can be configured in a typesafe way:
 
 ```typescript
-import { withDataService, withCallState, withUndoRedo } from '@angular-architects/ngrx-toolkit';
+import { withDataService, withCallState, withUndoRedo } from '@ngrx-toolkit/core';
 
 export const FlightBookingStore = signalStore(
   { providedIn: 'root' },

--- a/docs/docs/with-devtools.md
+++ b/docs/docs/with-devtools.md
@@ -3,7 +3,7 @@ title: withDevtools()
 ---
 
 ```typescript
-import { withDevtools } from '@angular-architects/ngrx-toolkit';
+import { withDevtools } from '@ngrx-toolkit/core';
 ```
 
 :::info
@@ -15,7 +15,7 @@ Redux Devtools is a powerful browser extension tool, that allows you to inspect 
 To use the Devtools, you need to add the `withDevtools()` extension to your SignalStore:
 
 ```typescript
-import { withDevtools } from '@angular-architects/ngrx-toolkit';
+import { withDevtools } from '@ngrx-toolkit/core';
 
 export const FlightStore = signalStore(
   { providedIn: 'root' },
@@ -27,7 +27,7 @@ export const FlightStore = signalStore(
 
 After that, open your app and navigate to the component that uses the store. Open the Devtools and you will see the `flights` store in the Devtools under the name "NgRx Signal Store"
 
-You can find a working example in the [demo app](https://github.com/angular-architects/ngrx-toolkit/blob/main/apps/demo/src/app/devtools/todo-store.ts).
+You can find a working example in the [demo app](https://github.com/ngrx-toolkit/ngrx-toolkit/blob/main/apps/demo/src/app/devtools/todo-store.ts).
 
 :::info
 The extensions don't activate during app initialization (as it is with `@ngrx/store`). You need to open the Devtools and select the "NgRx Signal Store" tab to activate them.
@@ -38,13 +38,13 @@ The extensions don't activate during app initialization (as it is with `@ngrx/st
 ## `updateState()` vs `patchState()`
 
 ```typescript
-import { updateState } from '@angular-architects/ngrx-toolkit';
+import { updateState } from '@ngrx-toolkit/core';
 ```
 
 The Signal Store does not use the Redux pattern, so there are no action names involved by default. Instead, every action is referred to as a "Store Update". If you want to customize the action name for better clarity, you can use the `updateState()` function instead of `patchState()`:
 
 ```typescript
-import { updateState } from '@angular-architects/ngrx-toolkit';
+import { updateState } from '@ngrx-toolkit/core';
 
 patchState(this.store, { loading: false });
 
@@ -55,7 +55,7 @@ updateState(this.store, 'update loading', { loading: false });
 ## `renameDevtoolsName()`
 
 ```typescript
-import { renameDevtoolsName } from '@angular-architects/ngrx-toolkit';
+import { renameDevtoolsName } from '@ngrx-toolkit/core';
 ```
 
 If multiple instances of a given SignalStore exist, the Devtools will index the names. For example, if you have two `TodoDetail` instances with the name `todo-detail`, the first one will be named `todo-detail` and the second one `todo-detail-1`.
@@ -65,7 +65,7 @@ At any time, you can use `renameDevtoolsName()` to change the name of the store 
 The following example shows a component, which has a locally provided store and renames it according to the `id` of the `todo` Signal.
 
 ```typescript
-import { renameDevtoolsName, withDevtools } from '@angular-architects/ngrx-toolkit';
+import { renameDevtoolsName, withDevtools } from '@ngrx-toolkit/core';
 
 const TodoDetailStore = signalStore(withDevtools('todo-detail'), withState({ id: 1 }));
 
@@ -88,7 +88,7 @@ export class TodoDetailComponent {
 ## `withGlitchTracking()`
 
 ```typescript
-import { withGlitchTracking } from '@angular-architects/ngrx-toolkit';
+import { withGlitchTracking } from '@ngrx-toolkit/core';
 ```
 
 It tracks all state changes of the State, including intermediary updates
@@ -99,7 +99,7 @@ This feature is especially useful for debugging.
 Example:
 
 ```typescript
-import { withGlitchTracking, withDevtools } from '@angular-architects/ngrx-toolkit';
+import { withGlitchTracking, withDevtools } from '@ngrx-toolkit/core';
 
 const Store = signalStore(
   { providedIn: 'root' },
@@ -125,7 +125,7 @@ It is also possible to mix. So one store could have `withGlitchTracking()` and a
 ## `withDisabledNameIndices()`
 
 ```typescript
-import { withDisabledNameIndices } from '@angular-architects/ngrx-toolkit';
+import { withDisabledNameIndices } from '@ngrx-toolkit/core';
 ```
 
 `withDevtools()` foresees the possibility to add features which extend or modify it. At the moment, `withDisabledNameIndices()` is the only feature available. It disables the automatic indexing of the store names in the Devtools.
@@ -135,7 +135,7 @@ If multiple instances exist at the same time, `withDisabledNameIndices()` will t
 You activate per store:
 
 ```typescript
-import { withDisabledNameIndices, withDevtools } from '@angular-architects/ngrx-toolkit';
+import { withDisabledNameIndices, withDevtools } from '@ngrx-toolkit/core';
 
 const Store = signalStore({ providedIn: 'root' }, withDevtools('flights', withDisabledNameIndices()), withState({ airline: 'Lufthansa' }));
 ```
@@ -143,7 +143,7 @@ const Store = signalStore({ providedIn: 'root' }, withDevtools('flights', withDi
 ## `withMapper()`
 
 ```typescript
-import { withMapper } from '@angular-architects/ngrx-toolkit';
+import { withMapper } from '@ngrx-toolkit/core';
 ```
 
 `withMapper()` allows you to define a function that maps the state before it is sent to the Devtools.
@@ -151,7 +151,7 @@ import { withMapper } from '@angular-architects/ngrx-toolkit';
 Sometimes, it is necessary to map the state before it is sent to the Devtools. For example, you might want to exclude some properties, like passwords or other sensitive data.
 
 ```typescript
-import { withMapper, withDevtools } from '@angular-architects/ngrx-toolkit';
+import { withMapper, withDevtools } from '@ngrx-toolkit/core';
 
 const initialState = {
   id: 1,
@@ -182,7 +182,7 @@ To use it
 
 ```ts
 // Must have all three, or runtime errors for thee!
-import { withTrackedReducer, withGlitchTracking, withDevtools } from '@angular-architects/ngrx-toolkit';
+import { withTrackedReducer, withGlitchTracking, withDevtools } from '@ngrx-toolkit/core';
 
 export const bookEvents = eventGroup({
   source: 'Book Store',
@@ -225,7 +225,7 @@ It is required to add the `withDevtools()` function to the environment files.
 environments/environment.ts:
 
 ```typescript
-import { withDevtools } from '@angular-architects/ngrx-toolkit';
+import { withDevtools } from '@ngrx-toolkit/core';
 
 export const environment = {
   storeWithDevTools: withDevtools,
@@ -235,7 +235,7 @@ export const environment = {
 environments/environment.prod.ts
 
 ```typescript
-import { withDevtoolsStub } from '@angular-architects/ngrx-toolkit';
+import { withDevtoolsStub } from '@ngrx-toolkit/core';
 
 export const environment = {
   storeWithDevTools: withDevToolsStub,

--- a/docs/docs/with-entity-resources.md
+++ b/docs/docs/with-entity-resources.md
@@ -3,7 +3,7 @@ title: withEntityResources()
 ---
 
 ```typescript
-import { withEntityResources } from '@angular-architects/ngrx-toolkit';
+import { withEntityResources } from '@ngrx-toolkit/core';
 ```
 
 `withEntityResources()` integrates Angular Resources that return arrays into NgRx SignalStore using the Entity helpers from `@ngrx/signals/entities`.
@@ -42,7 +42,7 @@ withEntityResources<
 import { signalStore, withState, patchState } from '@ngrx/signals';
 import { resource } from '@angular/core';
 import { addEntity } from '@ngrx/signals/entities';
-import { withEntityResources } from '@angular-architects/ngrx-toolkit';
+import { withEntityResources } from '@ngrx-toolkit/core';
 
 export type Todo = { id: number; title: string; completed: boolean };
 
@@ -66,7 +66,7 @@ The store now provides:
 ```typescript
 import { signalStore } from '@ngrx/signals';
 import { resource } from '@angular/core';
-import { withEntityResources } from '@angular-architects/ngrx-toolkit';
+import { withEntityResources } from '@ngrx-toolkit/core';
 
 export type Todo = { id: number; title: string; completed: boolean };
 
@@ -144,7 +144,7 @@ patchState(store, removeEntity(3, { collection: 'todos' }));
 See the demo store `todo-entity-resource` for a full example that combines mutations and entity resources.
 
 ```typescript
-import { httpMutation, withMutations, withEntityResources } from '@angular-architects/ngrx-toolkit';
+import { httpMutation, withMutations, withEntityResources } from '@ngrx-toolkit/core';
 import { inject, resource } from '@angular/core';
 import { patchState, signalStore, withMethods, withState } from '@ngrx/signals';
 import { addEntity, removeEntity, updateEntity } from '@ngrx/signals/entities';

--- a/docs/docs/with-feature-factory.md
+++ b/docs/docs/with-feature-factory.md
@@ -4,7 +4,7 @@ title: withFeatureFactory()
 
 ```typescript
 // DEPRECATED
-import { withFeatureFactory } from '@angular-architects/ngrx-toolkit';
+import { withFeatureFactory } from '@ngrx-toolkit/core';
 
 // Use this instead
 import { withFeature } from '@ngrx/signals';
@@ -24,5 +24,5 @@ Use `import { withFeature } from '@ngrx/signals'` instead.
 - NgRx PR: ["feat(signals): add `withFeature` #4739"](https://github.com/ngrx/platform/pull/4739)
 - NgRx [documentation section](https://ngrx.io/guide/signals/signal-store/custom-store-features#connecting-a-custom-feature-with-the-store) on `withFeature`
 
-In the future, `withFeatureFactory` will likely be removed, provided a right migration path is prepared. Watch out for PRs, and see [the PR that deprecates `withFeatureFactory` for the initial plan for handling the removal](https://github.com/angular-architects/ngrx-toolkit/pull/167#pullrequestreview-2735443379).
+In the future, `withFeatureFactory` will likely be removed, provided a right migration path is prepared. Watch out for PRs, and see [the PR that deprecates `withFeatureFactory` for the initial plan for handling the removal](https://github.com/ngrx-toolkit/ngrx-toolkit/pull/167#pullrequestreview-2735443379).
 :::

--- a/docs/docs/with-immutable-state.md
+++ b/docs/docs/with-immutable-state.md
@@ -3,7 +3,7 @@ title: withImmutableState()
 ---
 
 ```typescript
-import { withImmutableState } from '@angular-architects/ngrx-toolkit';
+import { withImmutableState } from '@ngrx-toolkit/core';
 ```
 
 `withImmutableState` acts like `withState` but protects
@@ -14,7 +14,7 @@ The protection is not limited to changes within the
 SignalStore but also outside of it.
 
 ```typescript
-import { withImmutableState } from '@angular-architects/ngrx-toolkit';
+import { withImmutableState } from '@ngrx-toolkit/core';
 
 const initialState = { user: { id: 1, name: 'Konrad' } };
 
@@ -68,7 +68,7 @@ By default, `withImmutableState` is only active in development mode.
 There is a way to enable it in production mode as well:
 
 ```typescript
-import { withImmutableState } from '@angular-architects/ngrx-toolkit';
+import { withImmutableState } from '@ngrx-toolkit/core';
 
 const UserStore = signalStore({ providedIn: 'root' }, withImmutableState(initialState, { enableInProduction: true }));
 ```

--- a/docs/docs/with-redux.md
+++ b/docs/docs/with-redux.md
@@ -4,7 +4,7 @@ title: withRedux()
 
 ```typescript
 // DEPRECATED
-import { withRedux } from '@angular-architects/ngrx-toolkit';
+import { withRedux } from '@ngrx-toolkit/core';
 
 // Use `@ngrx/signals/events` instead
 ```
@@ -27,7 +27,7 @@ There is also a [Redux Connector](./create-redux-state) available, which is a se
 Example:
 
 ```typescript
-import { withRedux } from '@angular-architects/ngrx-toolkit';
+import { withRedux } from '@ngrx-toolkit/core';
 
 export const FlightStore = signalStore(
   { providedIn: 'root' },
@@ -66,11 +66,11 @@ export const FlightStore = signalStore(
 ## Extracting actions, reducer and effects into separate files
 
 ```typescript
-import { createReducer } from '@angular-architects/ngrx-toolkit';
+import { createReducer } from '@ngrx-toolkit/core';
 ```
 
 ```typescript
-import { createEffects } from '@angular-architects/ngrx-toolkit';
+import { createEffects } from '@ngrx-toolkit/core';
 ```
 
 `createReducer` and `createEffects` allow you to extract the reducer and effects into separate files.
@@ -80,7 +80,7 @@ There is no need for a `createActions` function, because the actions are just an
 Example:
 
 ```typescript
-import { withRedux, createReducer, createEffects } from '@angular-architects/ngrx-toolkit';
+import { withRedux, createReducer, createEffects } from '@ngrx-toolkit/core';
 
 interface FlightState {
   flights: Flight[];
@@ -133,7 +133,7 @@ signalStore(
 ### Configuring the Redux Devtools Extension
 
 ```typescript
-import { provideDevtoolsConfig } from '@angular-architects/ngrx-toolkit';
+import { provideDevtoolsConfig } from '@ngrx-toolkit/core';
 ```
 
 The `provideDevtoolsConfig` function allows you to configure the Redux DevTools integration for your NgRx SignalStore. This function is essential for setting up the DevTools with custom options. The function only needs to be called once in your appConfig or AppModule.
@@ -145,7 +145,7 @@ Here is an example of how to use it with the standalone api:
 ```typescript
 // app.config.ts
 import { ApplicationConfig } from '@angular/core';
-import { provideDevtoolsConfig } from '@angular-architects/ngrx-toolkit';
+import { provideDevtoolsConfig } from '@ngrx-toolkit/core';
 
 export const appConfig: ApplicationConfig = {
   providers: [

--- a/docs/docs/with-reset.md
+++ b/docs/docs/with-reset.md
@@ -3,7 +3,7 @@ title: withReset()
 ---
 
 ```typescript
-import { withReset } from '@angular-architects/ngrx-toolkit';
+import { withReset } from '@ngrx-toolkit/core';
 ```
 
 `withReset()` adds a method to reset the state of the Signal Store to its initial value. Nothing more to say about it 😅
@@ -11,7 +11,7 @@ import { withReset } from '@angular-architects/ngrx-toolkit';
 Example:
 
 ```typescript
-import { withReset } from '@angular-architects/ngrx-toolkit';
+import { withReset } from '@ngrx-toolkit/core';
 
 const Store = signalStore(
   withState({
@@ -41,7 +41,7 @@ console.log(store.user()); // { id: 1, name: 'Konrad' }
 ## `setResetState()`
 
 ```typescript
-import { setResetState } from '@angular-architects/ngrx-toolkit';
+import { setResetState } from '@ngrx-toolkit/core';
 ```
 
 If you want to set a custom reset state, you can use the `setResetState()` method.
@@ -50,7 +50,7 @@ Example:
 
 ```typescript
 // continue from the previous example
-import { setResetState } from '@angular-architects/ngrx-toolkit';
+import { setResetState } from '@ngrx-toolkit/core';
 
 setResetState(store, { user: { id: 3, name: 'Jane' }, address: { city: 'Berlin', zip: '10115' } });
 store.changeUser(4, 'Alice');

--- a/docs/docs/with-resource.md
+++ b/docs/docs/with-resource.md
@@ -3,7 +3,7 @@ title: withResource()
 ---
 
 ```typescript
-import { withResource } from '@angular-architects/ngrx-toolkit';
+import { withResource } from '@ngrx-toolkit/core';
 ```
 
 > **⚠️ Important Note**: This extension is very likely to land in NgRx once Angular's `Resource` enters developer preview. The `withResource` extension provides early access to this functionality and will be maintained for compatibility until the official NgRx implementation is available.
@@ -36,7 +36,7 @@ The extension supports both single resource integration and multiple named resou
 ### Single Resource
 
 ```typescript
-import { withResource } from '@angular-architects/ngrx-toolkit';
+import { withResource } from '@ngrx-toolkit/core';
 import { signalStore, withState } from '@ngrx/signals';
 import { httpResource } from '@angular/core';
 
@@ -127,7 +127,7 @@ Options:
 1. `'previous value'`. The resource's previous value will be returned.
 1. `'native'`. No special handling is provided, inline with default error behavior.
 
-Under the hood, `'previous value'` and `'undefined value'` proxy the value. For a detailed explanation for why this is done, check out the [JSDoc for the error handling strategy](https://github.com/angular-architects/ngrx-toolkit/blob/main/libs/ngrx-toolkit/src/lib/with-resource.ts#L402).
+Under the hood, `'previous value'` and `'undefined value'` proxy the value. For a detailed explanation for why this is done, check out the [JSDoc for the error handling strategy](https://github.com/ngrx-toolkit/ngrx-toolkit/blob/main/libs/ngrx-toolkit/src/lib/with-resource.ts#L402).
 
 The implications of `undefined value` is that the inferred value can be `undefined`, even if there is a `defaultValue` set for the resource.
 For example, in the [`Updating`](#updating) section, `listValue` will be inferred as `User[] | undefined`. To be able to infer the type with a guaranteed value,
@@ -159,7 +159,7 @@ export class UserDetail {
 For named resources, you can use the `mapToResource` utility to get a properly typed `Resource<T>`:
 
 ```typescript
-import { mapToResource } from '@angular-architects/ngrx-toolkit';
+import { mapToResource } from '@ngrx-toolkit/core';
 
 const store = signalStore(
   withState({ userId: undefined as number | undefined }),

--- a/docs/docs/with-storage-sync.md
+++ b/docs/docs/with-storage-sync.md
@@ -11,7 +11,7 @@ As Web Storage and IndexedDB only work in browser environments, it will fallback
 Example:
 
 ```typescript
-import { withStorageSync } from '@angular-architects/ngrx-toolkit';
+import { withStorageSync } from '@ngrx-toolkit/core';
 
 const UserStore = signalStore(
   withState({ name: 'John' }),
@@ -109,7 +109,7 @@ const UserStore = signalStore(
 Use `withSessionStorage()` to synchronize with `sessionStorage` instead of `localStorage`.
 
 ```typescript
-import { withSessionStorage, withStorageSync } from '@angular-architects/ngrx-toolkit';
+import { withSessionStorage, withStorageSync } from '@ngrx-toolkit/core';
 
 const UserStore = signalStore(withState({ name: 'John' }), withStorageSync('user', withSessionStorage()));
 ```
@@ -124,7 +124,7 @@ Notes:
 Use `withIndexedDB()` to synchronize with IndexedDB. Because IndexedDB is asynchronous, all reads and writes are performed asynchronously. You must wait for the initial read during app initialization (via `whenSynced()`), and we recommend disabling auto sync for predictable sequencing and better DX (avoids sprinkling `whenSynced()` after each change).
 
 ```typescript
-import { withIndexedDB, withStorageSync } from '@angular-architects/ngrx-toolkit';
+import { withIndexedDB, withStorageSync } from '@ngrx-toolkit/core';
 import { withHooks, patchState } from '@ngrx/signals';
 
 // Recommended: disable autoSync to control sequencing explicitly

--- a/docs/docs/with-undo-redo.md
+++ b/docs/docs/with-undo-redo.md
@@ -3,7 +3,7 @@ title: withUndoRedo()
 ---
 
 ```typescript
-import { withUndoRedo } from '@angular-architects/ngrx-toolkit';
+import { withUndoRedo } from '@ngrx-toolkit/core';
 ```
 
 `withUndoRedo` adds undo and redo functionality to the store.
@@ -11,8 +11,8 @@ import { withUndoRedo } from '@angular-architects/ngrx-toolkit';
 Example:
 
 ```typescript
-import { withUndoRedo } from '@angular-architects/ngrx-toolkit';
-import { clearUndoRedo } from '@angular-architects/ngrx-toolkit';
+import { withUndoRedo } from '@ngrx-toolkit/core';
+import { clearUndoRedo } from '@ngrx-toolkit/core';
 
 const SyncStore = signalStore(
   withUndoRedo({
@@ -25,7 +25,7 @@ const SyncStore = signalStore(
 ```
 
 ```typescript
-import { clearUndoRedo } from '@angular-architects/ngrx-toolkit';
+import { clearUndoRedo } from '@ngrx-toolkit/core';
 
 @Component(...)
 public class UndoRedoComponent {

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -114,7 +114,7 @@ const config: Config = {
     },
     footer: {
       style: 'dark',
-      copyright: `Copyright © ${new Date().getFullYear()} Community & Angular Architects`,
+      copyright: `Copyright © ${new Date().getFullYear()} NgRx Toolkit contributors`,
     },
     prism: {
       theme: prismThemes.github,

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -10,14 +10,14 @@ const config: Config = {
   favicon: 'img/favicon.ico',
 
   // Set the production url of your site here
-  url: 'https://angular-architects.github.io',
+  url: 'https://ngrx-toolkit.github.io',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/',
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
-  organizationName: 'angular-architects', // Usually your GitHub org/user name.
+  organizationName: 'ngrx-toolkit', // Usually your GitHub org/user name.
   projectName: 'ngrx-toolkit', // Usually your repo name.
   deploymentBranch: 'main',
   onBrokenLinks: 'throw',
@@ -53,7 +53,7 @@ const config: Config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/angular-architects/ngrx-toolkit/tree/main/docs/',
+            'https://github.com/ngrx-toolkit/ngrx-toolkit/tree/main/docs/',
         },
         blog: false,
         theme: {
@@ -101,7 +101,7 @@ const config: Config = {
           label: 'Community',
         },
         {
-          href: 'https://github.com/angular-architects/ngrx-toolkit',
+          href: 'https://github.com/ngrx-toolkit/ngrx-toolkit',
           label: 'GitHub',
           position: 'right',
         },

--- a/docs/src/components/Team/index.tsx
+++ b/docs/src/components/Team/index.tsx
@@ -16,7 +16,7 @@ const teamMembers: TeamMember[] = [
   { 
     name: 'Rainer Hahnekamp', 
     image: '/img/team/rainer-hahnekamp.jpg',
-    description: 'Google Developer Expert (GDE) and a member of the NgRx team. Trainer and consultant in the Angular Architects expert network and runs ng-news, a weekly Angular newsletter.'
+    description: 'Google Developer Expert (GDE) and a member of the NgRx team. Runs ng-news, a weekly Angular newsletter.'
   },
   { 
     name: 'Michael Small', 

--- a/docs/src/components/Team/index.tsx
+++ b/docs/src/components/Team/index.tsx
@@ -16,7 +16,7 @@ const teamMembers: TeamMember[] = [
   { 
     name: 'Rainer Hahnekamp', 
     image: '/img/team/rainer-hahnekamp.jpg',
-    description: 'Google Developer Expert (GDE) and a member of the NgRx team. Runs ng-news, a weekly Angular newsletter.'
+    description: 'Google Developer Expert (GDE) and member of the NgRx team, focused on Angular, AI engineering, and agentic applications. Runs ng-news, a weekly Angular newsletter.'
   },
   { 
     name: 'Michael Small', 

--- a/libs/ngrx-toolkit/README.md
+++ b/libs/ngrx-toolkit/README.md
@@ -1,6 +1,6 @@
 # NgRx Toolkit
 
-<img src="https://raw.githubusercontent.com/angular-architects/ngrx-toolkit/main/logo.png" width="320" />
+<img src="https://raw.githubusercontent.com/ngrx-toolkit/ngrx-toolkit/main/logo.png" width="320" />
 
 NgRx Toolkit is a set of extensions to the NgRx Signals Store, like
 
@@ -8,6 +8,8 @@ NgRx Toolkit is a set of extensions to the NgRx Signals Store, like
 - Redux: Possibility to use the Redux Pattern (Reducer, Actions, Effects)
 - Storage Sync: Synchronize the Store with Web Storage
 - Redux Connector: Map NgRx Store Actions to a present Signal Store
+
+> Starting with v22, the package is published as `@ngrx-toolkit/core`. For v21 and earlier, use `@angular-architects/ngrx-toolkit`.
 
 For a more detailed guide on installation, setup, and usage, head to the [**Documentation**](https://ngrx-toolkit.angulararchitects.io//).
 

--- a/libs/ngrx-toolkit/package.json
+++ b/libs/ngrx-toolkit/package.json
@@ -1,10 +1,13 @@
 {
-  "name": "@angular-architects/ngrx-toolkit",
+  "name": "@ngrx-toolkit/core",
   "version": "22.0.0",
   "license": "MIT",
   "repository": {
     "type": "GitHub",
-    "url": "https://github.com/angular-architects/ngrx-toolkit"
+    "url": "https://github.com/ngrx-toolkit/ngrx-toolkit"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "peerDependencies": {
     "@angular/core": "^22.0.0",

--- a/libs/ngrx-toolkit/redux-connector/docs/README.md
+++ b/libs/ngrx-toolkit/redux-connector/docs/README.md
@@ -1,6 +1,6 @@
 # Redux Connector for the NgRx Signal Store `createReduxState()`
 
-The Redux Connector turns any `signalStore()` into a Global State Management Slice following the Redux pattern. It is available as secondary entry point, i.e. `import { createReduxState } from '@angular-architects/ngrx-toolkit/redux-connector'` and has a dependency to `@ngrx/store`.
+The Redux Connector turns any `signalStore()` into a Global State Management Slice following the Redux pattern. It is available as secondary entry point, i.e. `import { createReduxState } from '@ngrx-toolkit/core/redux-connector'` and has a dependency to `@ngrx/store`.
 
 It supports:
 

--- a/libs/ngrx-toolkit/src/lib/devtools/with-devtools.ts
+++ b/libs/ngrx-toolkit/src/lib/devtools/with-devtools.ts
@@ -15,7 +15,7 @@ import {
 import { DevtoolsSyncer } from './internal/devtools-syncer.service';
 import { ReduxDevtoolsExtension } from './internal/models';
 
-// Users requested that we export this type: https://github.com/angular-architects/ngrx-toolkit/issues/178
+// Users requested that we export this type: https://github.com/ngrx-toolkit/ngrx-toolkit/issues/178
 export type DevtoolsFeature = DevtoolsFeatureInternal;
 
 declare global {

--- a/libs/ngrx-toolkit/src/lib/with-mutations.spec.ts
+++ b/libs/ngrx-toolkit/src/lib/with-mutations.spec.ts
@@ -538,7 +538,7 @@ describe('withMutations with rxMutation', () => {
   });
 
   it('does not expose mutation properties directly, only the method', async () => {
-    // Test case for https://github.com/angular-architects/ngrx-toolkit/issues/286
+    // Test case for https://github.com/ngrx-toolkit/ngrx-toolkit/issues/286
     const testSetup = createTestSetup(switchOp);
     const store = testSetup.store;
 
@@ -548,7 +548,7 @@ describe('withMutations with rxMutation', () => {
   });
 
   it('types mutation method as plain callable Promise signature and returns nothing else from a mutation', () => {
-    // Test case for https://github.com/angular-architects/ngrx-toolkit/issues/286
+    // Test case for https://github.com/ngrx-toolkit/ngrx-toolkit/issues/286
     const testSetup = createTestSetup();
     const store = testSetup.store;
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,8 +15,8 @@
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
     "paths": {
-      "@angular-architects/ngrx-toolkit": ["libs/ngrx-toolkit/src/index.ts"],
-      "@angular-architects/ngrx-toolkit/redux-connector": [
+      "@ngrx-toolkit/core": ["libs/ngrx-toolkit/src/index.ts"],
+      "@ngrx-toolkit/core/redux-connector": [
         "libs/ngrx-toolkit/redux-connector"
       ]
     },


### PR DESCRIPTION
## Summary

- rename the v22 npm package to @ngrx-toolkit/core
- update demo imports, documentation examples, TypeScript aliases, repository links, and the redux-connector entry point
- add v22 migration notices and mark the new scoped package for public publication

## Validation

- full lint, unit-test, library-build, and demo-build suite passes
- 30 test suites pass with 364 tests passing, 1 skipped, and 3 todo
- formatting and diff checks pass
- package dry run produces @ngrx-toolkit/core@22.0.0 with both entry points

## Local environment notes

- Playwright reached the demo server but Chromium could not launch locally with spawn error -88; hosted CI should provide the e2e result
- the docs build still hits existing TypeScript ignoreDeprecations and broken /docs/api/globals configuration errors unrelated to this rename